### PR TITLE
Support for Laravel 13

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -14,16 +14,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: '8.4'
           coverage: none
 
       - name: Install composer dependencies
-        uses: ramsey/composer-install@v3
+        uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
 
       - name: Run PHPStan
         run: ./vendor/bin/phpstan --error-format=github

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,11 +18,14 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.4, 8.5]
-        laravel: [12.*]
+        laravel: [12.*, 13.*]
         stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: 12.*
             testbench: 10.*
+            carbon: ^3.0
+          - laravel: 13.*
+            testbench: 11.*
             carbon: ^3.0
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -32,10 +32,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo

--- a/composer.json
+++ b/composer.json
@@ -5,13 +5,13 @@
     "license": "MIT",
     "require": {
         "php": "^8.4",
-        "illuminate/contracts": "^12.0||^11.0",
+        "illuminate/contracts": "^13.0||^12.0||^11.0",
         "thecodingmachine/safe": "^3.3"
     },
     "require-dev": {
         "nunomaduro/collision": "^8.8",
         "larastan/larastan": "^3.6",
-        "orchestra/testbench": "^10.0.0||^9.0.0||^8.22.0",
+        "orchestra/testbench": "^11.0.0||^10.0.0||^9.0.0||^8.22.0",
         "friendsofphp/php-cs-fixer": "^3.3",
         "lychee-org/phpstan-lychee": "^v2.0.2",
         "php-parallel-lint/php-parallel-lint": "^1.4",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test matrix to cover Laravel 13 alongside existing versions.

* **Chores**
  * Updated dependency constraints for `illuminate/contracts` (now includes ^13.0) and `orchestra/testbench` (now includes ^11.0.0) to support additional versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->